### PR TITLE
FEA Implement support for multiple concurrent games

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PonGo
 
-![Coverage](https://img.shields.io/badge/Coverage-59.0%25-yellow)
+![Coverage](https://img.shields.io/badge/Coverage-59.2%25-yellow)
 ![Unit-tests](https://img.shields.io/github/actions/workflow/status/lguibr/pongo/test.yml?label=UnitTests)
 ![Building](https://img.shields.io/github/actions/workflow/status/lguibr/pongo/build.yml?label=Build)
 ![Lint](https://img.shields.io/github/actions/workflow/status/lguibr/pongo/lint.yml?label=Lint)

--- a/game/game.go
+++ b/game/game.go
@@ -78,7 +78,7 @@ func (game *Game) GetNextIndex() int {
 			return i
 		}
 	}
-	return 0
+	return -1
 }
 
 func (game *Game) HasPlayer() bool {

--- a/game/game_test.go
+++ b/game/game_test.go
@@ -36,7 +36,7 @@ func TestGame_GetNextIndex(t *testing.T) {
 		{[4]*Player{{Id: "player1"}, nil, nil}, 1},
 		{[4]*Player{{Id: "player1"}, {Id: "player2"}, nil}, 2},
 		{[4]*Player{{Id: "player1"}, {Id: "player2"}, {Id: "player3"}}, 3},
-		{[4]*Player{{Id: "player1"}, {Id: "player2"}, {Id: "player3"}, {Id: "player4"}}, 0},
+		{[4]*Player{{Id: "player1"}, {Id: "player2"}, {Id: "player3"}, {Id: "player4"}}, -1},
 	}
 
 	for _, tc := range testCases {

--- a/main.go
+++ b/main.go
@@ -12,13 +12,11 @@ import (
 var port = ":3001"
 
 func main() {
-	g := game.StartGame()
-	go g.ReadGameChannel()
 
+	var games []*game.Game
+	games = append(games, game.StartGame())
 	websocketServer := server.New()
 	fmt.Println("Server started on port", port)
-	http.HandleFunc("/", websocketServer.HandleGetSit(g))
-	http.Handle("/subscribe", websocket.Handler(websocketServer.HandleSubscribe(g)))
-
+	http.Handle("/subscribe", websocket.Handler(websocketServer.HandleSubscribe(games)))
 	panic(http.ListenAndServe(port, nil))
 }

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -1,33 +1,40 @@
 package server
 
 import (
-	"fmt"
-	"io"
-	"net/http"
-
 	"github.com/lguibr/pongo/game"
 
 	"golang.org/x/net/websocket"
 )
 
-func (s *Server) HandleSubscribe(g *game.Game) func(ws *websocket.Conn) {
+func (s *Server) HandleSubscribe(games []*game.Game) func(ws *websocket.Conn) {
 	return func(ws *websocket.Conn) {
+		var currentGameIndex int = -1
+		var currentGame *game.Game
+
+		for _, game := range games {
+			if game != nil && game.GetNextIndex() != -1 {
+				currentGame = game
+				break
+			}
+		}
+		noAvailableGame := currentGameIndex == -1
+
+		if noAvailableGame {
+			currentGame := game.StartGame()
+			games = append(games, currentGame)
+		} else {
+			currentGame = games[currentGameIndex]
+		}
+
+		go currentGame.ReadGameChannel()
+
 		//INFO Open WebSocket connection
 		s.OpenConnection(ws)
 		//INFO Start Game lifecycle
-		go g.LifeCycle(ws, func() { s.CloseConnection(ws) })
+		go currentGame.LifeCycle(ws, func() {
+			s.CloseConnection(ws)
+		})
 		//INFO Keep WebSocket connection open
 		s.KeepConnection(ws)
-	}
-}
-
-func (s *Server) HandleGetSit(g *game.Game) func(w http.ResponseWriter, r *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		_, err := io.WriteString(w, string(g.ToJson()))
-		if err != nil {
-			fmt.Println("Error writing to client: ", err)
-		}
 	}
 }


### PR DESCRIPTION
* Introduce an array to hold multiple Game instances
* Check for an available game slot when a new player connects
  - If no available slot, start a new game and add it to the array
  - If an available slot exists, assign the player to that game
* Each game instance runs independently with its own lifecycle and communication channel
* Remove the unused HandleGetSit handler

This commit introduces the capability to host multiple concurrent Pongo games. When a new player connects via WebSocket, the server checks for an available slot in the existing games. If no slot is available, a new game instance is started and added to the games array. This allows multiple games to run simultaneously, each with its own lifecycle and communication channel. The HandleGetSit handler has been removed as it is no longer needed in this implementation.